### PR TITLE
fixing issue with view sizes for specific multitasking case

### DIFF
--- a/Pod/Classes/SideMenuManager.swift
+++ b/Pod/Classes/SideMenuManager.swift
@@ -46,7 +46,7 @@ public class SideMenuManager {
     public static var menuAllowPopIfPossible = false
     
     /// Width of the menu when presented on screen, showing the existing view controller in the remaining space. Default is 75% of the screen width.
-    public static var menuWidth: CGFloat = max(round(min(UIScreen.mainScreen().bounds.width, UIScreen.mainScreen().bounds.height) * 0.75), 240)
+    public static var menuWidth: CGFloat = max(round(min((UIApplication.sharedApplication().keyWindow?.bounds.width)!, (UIApplication.sharedApplication().keyWindow?.bounds.height)!) * 0.75), 240)
     
     /// Duration of the animation when the menu is presented without gestures. Default is 0.35 seconds.
     public static var menuAnimationPresentDuration = 0.35

--- a/Pod/Classes/SideMenuManager.swift
+++ b/Pod/Classes/SideMenuManager.swift
@@ -46,7 +46,7 @@ public class SideMenuManager {
     public static var menuAllowPopIfPossible = false
     
     // Bounds which has been allocated for the app on the whole device screen
-    public static var appScreenRect: CGRect {
+    static var appScreenRect: CGRect {
         let appWindowRect = (UIApplication.sharedApplication().keyWindow != nil) ? UIApplication.sharedApplication().keyWindow!.bounds : UIWindow().bounds
         return appWindowRect
     }

--- a/Pod/Classes/SideMenuManager.swift
+++ b/Pod/Classes/SideMenuManager.swift
@@ -45,8 +45,14 @@ public class SideMenuManager {
     /// Pops to any view controller already in the navigation stack instead of the view controller being pushed if they share the same class. Defaults to false.
     public static var menuAllowPopIfPossible = false
     
+    // Bounds which has been allocated for the app on the whole device screen
+    public static var appScreenRect: CGRect {
+        let appWindowRect = (UIApplication.sharedApplication().keyWindow != nil) ? UIApplication.sharedApplication().keyWindow!.bounds : UIWindow().bounds
+        return appWindowRect
+    }
+    
     /// Width of the menu when presented on screen, showing the existing view controller in the remaining space. Default is 75% of the screen width.
-    public static var menuWidth: CGFloat = max(round(min((UIApplication.sharedApplication().keyWindow?.bounds.width)!, (UIApplication.sharedApplication().keyWindow?.bounds.height)!) * 0.75), 240)
+    public static var menuWidth: CGFloat = max(round(min((appScreenRect.width), (appScreenRect.height)) * 0.75), 240)
     
     /// Duration of the animation when the menu is presented without gestures. Default is 0.35 seconds.
     public static var menuAnimationPresentDuration = 0.35

--- a/Pod/Classes/SideMenuTransition.swift
+++ b/Pod/Classes/SideMenuTransition.swift
@@ -204,7 +204,7 @@ internal class SideMenuTransition: UIPercentDrivenInteractiveTransition, UIViewC
         originalSuperview?.addSubview(mainViewController.view)
     }
     
-    internal class func presentMenuStart(forSize size: CGSize = (UIApplication.sharedApplication().keyWindow?.bounds.size)!) {
+    internal class func presentMenuStart(forSize size: CGSize = SideMenuManager.appScreenRect.size) {
         guard let menuView = SideMenuTransition.presentDirection == .Left ? SideMenuManager.menuLeftNavigationController?.view : SideMenuManager.menuRightNavigationController?.view else {
             return
         }

--- a/Pod/Classes/SideMenuTransition.swift
+++ b/Pod/Classes/SideMenuTransition.swift
@@ -204,7 +204,7 @@ internal class SideMenuTransition: UIPercentDrivenInteractiveTransition, UIViewC
         originalSuperview?.addSubview(mainViewController.view)
     }
     
-    internal class func presentMenuStart(forSize size: CGSize = UIScreen.mainScreen().bounds.size) {
+    internal class func presentMenuStart(forSize size: CGSize = (UIApplication.sharedApplication().keyWindow?.bounds.size)!) {
         guard let menuView = SideMenuTransition.presentDirection == .Left ? SideMenuManager.menuLeftNavigationController?.view : SideMenuManager.menuRightNavigationController?.view else {
             return
         }


### PR DESCRIPTION
when running app with side menu on iPad device in Split View mode - it
takes wrong size for main view controller and side menu table view
controller (it is caused by taking sizes from UIScreen not from
UIApplication)