### PR TITLE
Add more Swift to Obj-C compatibility

### DIFF
--- a/Pod/Classes/SideMenuManager.swift
+++ b/Pod/Classes/SideMenuManager.swift
@@ -235,6 +235,19 @@ open class SideMenuManager : NSObject {
     }
     
     /**
+     Adds screen edge gestures to a view to present a menu for both sides.
+     
+     - Parameter toView: The view to add gestures to.
+     
+     - Returns: The array of screen edge gestures added to `toView`.
+     */
+    @discardableResult open class func menuAddScreenEdgePanGesturesToPresent(toView: UIView) -> [UIScreenEdgePanGestureRecognizer] {
+        return [UIRectEdge.left, UIRectEdge.right].flatMap {
+            SideMenuManager.menuAddScreenEdgePanGesturesToPresent(toView: toView, forMenu: $0).first ?? nil
+        }
+    }
+    
+    /**
      Adds screen edge gestures to a view to present a menu.
      
      - Parameter toView: The view to add gestures to.
@@ -242,7 +255,7 @@ open class SideMenuManager : NSObject {
  
      - Returns: The array of screen edge gestures added to `toView`.
      */
-    @discardableResult open class func menuAddScreenEdgePanGesturesToPresent(toView: UIView, forMenu:UIRectEdge? = nil) -> [UIScreenEdgePanGestureRecognizer] {
+    @discardableResult open class func menuAddScreenEdgePanGesturesToPresent(toView: UIView, forMenu: UIRectEdge) -> [UIScreenEdgePanGestureRecognizer] {
         var array = [UIScreenEdgePanGestureRecognizer]()
         
         if forMenu != .right {


### PR DESCRIPTION
This pull request primarily makes `menuAddScreenEdgePanGesturesToPresent` compatible with Obj-C . It was unable to find a solution to port `menuBlurEffectStyle` elegantly.

Swift has optionals for all types which works in most cases when being
used in Obj-C projects. However optional primitive types
(non-heap-allocated, like enums in this case) can’t be converted, and
whatever variables of functions that use them are invisible to Obj-C.

Another impossibility to convert was the default parameter, so I had to
add convenience function to call the full one.