### PR TITLE
Allow SideMenu to be called from tabbar controller

### DIFF
--- a/Pod/Classes/UISideMenuNavigationController.swift
+++ b/Pod/Classes/UISideMenuNavigationController.swift
@@ -125,11 +125,16 @@ open class UISideMenuNavigationController: UINavigationController {
             super.pushViewController(viewController, animated: animated)
             return
         }
-        
-        guard let presentingViewController = (presentingViewController as? UITabBarController)?.selectedViewController as? UINavigationController else {
+
+        var presentingViewControllerOptional = self.presentingViewController as? UINavigationController
+        if presentingViewControllerOptional == nil {
+            presentingViewControllerOptional =  (self.presentingViewController as? UITabBarController)?.selectedViewController as? UINavigationController
+        } else {
             print("SideMenu Warning: attempt to push a View Controller from \(self.presentingViewController.self) where its navigationController == nil. It must be embedded in a Navigation Controller for this to work.")
             return
         }
+
+        let presentingViewController = presentingViewControllerOptional!
         
         // to avoid overlapping dismiss & pop/push calls, create a transaction block where the menu
         // is dismissed after showing the appropriate screen

--- a/Pod/Classes/UISideMenuNavigationController.swift
+++ b/Pod/Classes/UISideMenuNavigationController.swift
@@ -126,7 +126,7 @@ open class UISideMenuNavigationController: UINavigationController {
             return
         }
         
-        guard let presentingViewController = presentingViewController as? UINavigationController else {
+        guard let presentingViewController = (presentingViewController as? UITabBarController)?.selectedViewController as? UINavigationController else {
             print("SideMenu Warning: attempt to push a View Controller from \(self.presentingViewController.self) where its navigationController == nil. It must be embedded in a Navigation Controller for this to work.")
             return
         }


### PR DESCRIPTION
This implements the solution proposed by @albernackee in #8 Currently if you try to try to present the sidemenu from a scene embedded in a tab bar controller you will receive a warning saying that the navigation controller is nil. This fix makes the presenting view controller not be the tab bar itself, but the controller embedded inside of the nav controller.

Feeback is appreciated