### PR TITLE
Changed default hide on transition / "Preserve" Feature / Enum of Push Behaviors

### DIFF
--- a/Pod/Classes/SideMenuManager.swift
+++ b/Pod/Classes/SideMenuManager.swift
@@ -114,10 +114,7 @@ open class SideMenuManager : NSObject {
     @available(*, deprecated, renamed: "menuPushBehavior", message: "Use `menuPushBehavior = .popWhenPossible` instead.")
     open static var menuAllowPopIfPossible: Bool {
         get {
-            if menuPushBehavior == .popWhenPossible {
-                return true
-            }
-            return false
+            return menuPushBehavior == .popWhenPossible
         }
         set {
             if newValue {
@@ -130,10 +127,7 @@ open class SideMenuManager : NSObject {
     @available(*, deprecated, renamed: "menuPushBehavior", message: "Use `menuPushBehavior = .replace` instead.")
     open static var menuReplaceOnPush: Bool {
         get {
-            if menuPushBehavior == .replace {
-                return true
-            }
-            return false
+            return menuPushBehavior == .replace
         }
         set {
             if newValue {

--- a/Pod/Classes/SideMenuManager.swift
+++ b/Pod/Classes/SideMenuManager.swift
@@ -61,7 +61,7 @@ open class SideMenuManager : NSObject {
      - menuDissolveIn: The menu dissolves in over the existing view controller.
      */
     open static var menuPresentMode: MenuPresentMode = .viewSlideOut
-
+    
     /// Prevents the same view controller (or a view controller of the same class) from being pushed more than once. Defaults to true.
     open static var menuAllowPushOfSameClassTwice = true
     

--- a/Pod/Classes/SideMenuManager.swift
+++ b/Pod/Classes/SideMenuManager.swift
@@ -42,7 +42,7 @@ open class SideMenuManager : NSObject {
      */
     open static var menuPresentMode: MenuPresentMode = .viewSlideOut
     
-    /// Retrieves each already created view controller to front when called. Requires class restoration identifiers. Defaults to false.
+    /// Retrieves each already created view controller to front when called. Disables navigation back button. Defaults to false.
     open static var menuPreserveViewOnPush = false
     
     /// Prevents the same view controller (or a view controller of the same class) from being pushed more than once. Defaults to true.

--- a/Pod/Classes/SideMenuManager.swift
+++ b/Pod/Classes/SideMenuManager.swift
@@ -47,7 +47,7 @@ open class SideMenuManager : NSObject {
      - popWhenPossible: Pops to any view controller already in the navigation stack instead of the view controller being pushed if they share the same class.
      - preserve: Retrieves each already created view controller to front when called.
      - preserveAndHideBackButton: Retrieves each already created view controller to front when called, and hides the back button.
-     - replace: Releases the current view controller and pushes the new view controller.
+     - replace: Releases the current view controller and pushes the new view controller. Hides the back button by default.
      */
     open static var menuPushBehavior: MenuPushBehavior = .defaultBehavior
 

--- a/Pod/Classes/SideMenuManager.swift
+++ b/Pod/Classes/SideMenuManager.swift
@@ -6,14 +6,14 @@
 //
 
 /* Example usage:
- // Define the menus
- SideMenuManager.menuLeftNavigationController = storyboard!.instantiateViewController(withIdentifier: "LeftMenuNavigationController") as? UISideMenuNavigationController
- SideMenuManager.menuRightNavigationController = storyboard!.instantiateViewController(withIdentifier: "RightMenuNavigationController") as? UISideMenuNavigationController
- 
- // Enable gestures. The left and/or right menus must be set up above for these to work.
- // Note that these continue to work on the Navigation Controller independent of the View Controller it displays!
- SideMenuManager.menuAddPanGestureToPresent(toView: self.navigationController!.navigationBar)
- SideMenuManager.menuAddScreenEdgePanGesturesToPresent(toView: self.navigationController!.view)
+     // Define the menus
+     SideMenuManager.menuLeftNavigationController = storyboard!.instantiateViewController(withIdentifier: "LeftMenuNavigationController") as? UISideMenuNavigationController
+     SideMenuManager.menuRightNavigationController = storyboard!.instantiateViewController(withIdentifier: "RightMenuNavigationController") as? UISideMenuNavigationController
+     
+     // Enable gestures. The left and/or right menus must be set up above for these to work.
+     // Note that these continue to work on the Navigation Controller independent of the View Controller it displays!
+     SideMenuManager.menuAddPanGestureToPresent(toView: self.navigationController!.navigationBar)
+     SideMenuManager.menuAddScreenEdgePanGesturesToPresent(toView: self.navigationController!.view)
  */
 
 open class SideMenuManager : NSObject {
@@ -30,7 +30,7 @@ open class SideMenuManager : NSObject {
         let appWindowRect = UIApplication.shared.keyWindow?.bounds ?? UIWindow().bounds
         return appWindowRect
     }
-    
+
     /**
      The presentation mode of the menu.
      
@@ -257,7 +257,7 @@ open class SideMenuManager : NSObject {
      
      - Parameter toView: The view to add gestures to.
      - Parameter forMenu: The menu (left or right) you want to add a gesture for. If unspecified, gestures will be added for both sides.
-     
+
      - Returns: The array of screen edge gestures added to `toView`.
      */
     @discardableResult open class func menuAddScreenEdgePanGesturesToPresent(toView: UIView, forMenu:UIRectEdge? = nil) -> [UIScreenEdgePanGestureRecognizer] {

--- a/Pod/Classes/SideMenuManager.swift
+++ b/Pod/Classes/SideMenuManager.swift
@@ -45,9 +45,6 @@ open class SideMenuManager : NSObject {
     /// Retrieves each already created view controller to front when called. Requires class restoration identifiers. Defaults to false.
     open static var menuPreserveViewOnPush = false
     
-    /// Mimics a tab function, by instantly presenting the view controller. Defaults to false.
-    open static var menuTabMode = false
-    
     /// Prevents the same view controller (or a view controller of the same class) from being pushed more than once. Defaults to true.
     open static var menuAllowPushOfSameClassTwice = true
     

--- a/Pod/Classes/SideMenuManager.swift
+++ b/Pod/Classes/SideMenuManager.swift
@@ -6,15 +6,15 @@
 //
 
 /* Example usage:
-     // Define the menus
-     SideMenuManager.menuLeftNavigationController = storyboard!.instantiateViewController(withIdentifier: "LeftMenuNavigationController") as? UISideMenuNavigationController
-     SideMenuManager.menuRightNavigationController = storyboard!.instantiateViewController(withIdentifier: "RightMenuNavigationController") as? UISideMenuNavigationController
-     
-     // Enable gestures. The left and/or right menus must be set up above for these to work.
-     // Note that these continue to work on the Navigation Controller independent of the View Controller it displays!
-     SideMenuManager.menuAddPanGestureToPresent(toView: self.navigationController!.navigationBar)
-     SideMenuManager.menuAddScreenEdgePanGesturesToPresent(toView: self.navigationController!.view)
-*/
+ // Define the menus
+ SideMenuManager.menuLeftNavigationController = storyboard!.instantiateViewController(withIdentifier: "LeftMenuNavigationController") as? UISideMenuNavigationController
+ SideMenuManager.menuRightNavigationController = storyboard!.instantiateViewController(withIdentifier: "RightMenuNavigationController") as? UISideMenuNavigationController
+ 
+ // Enable gestures. The left and/or right menus must be set up above for these to work.
+ // Note that these continue to work on the Navigation Controller independent of the View Controller it displays!
+ SideMenuManager.menuAddPanGestureToPresent(toView: self.navigationController!.navigationBar)
+ SideMenuManager.menuAddScreenEdgePanGesturesToPresent(toView: self.navigationController!.view)
+ */
 
 open class SideMenuManager : NSObject {
     
@@ -30,7 +30,7 @@ open class SideMenuManager : NSObject {
         let appWindowRect = UIApplication.shared.keyWindow?.bounds ?? UIWindow().bounds
         return appWindowRect
     }
-
+    
     /**
      The presentation mode of the menu.
      
@@ -41,6 +41,12 @@ open class SideMenuManager : NSObject {
      - menuDissolveIn: The menu dissolves in over the existing view controller.
      */
     open static var menuPresentMode: MenuPresentMode = .viewSlideOut
+    
+    /// Retrieves each already created view controller to front when called. Requires class restoration identifiers. Defaults to false.
+    open static var menuPreserveViewOnPush = false
+    
+    /// Mimics a tab function, by instantly presenting the view controller. Defaults to false.
+    open static var menuTabMode = false
     
     /// Prevents the same view controller (or a view controller of the same class) from being pushed more than once. Defaults to true.
     open static var menuAllowPushOfSameClassTwice = true
@@ -251,7 +257,7 @@ open class SideMenuManager : NSObject {
      
      - Parameter toView: The view to add gestures to.
      - Parameter forMenu: The menu (left or right) you want to add a gesture for. If unspecified, gestures will be added for both sides.
- 
+     
      - Returns: The array of screen edge gestures added to `toView`.
      */
     @discardableResult open class func menuAddScreenEdgePanGesturesToPresent(toView: UIView, forMenu:UIRectEdge? = nil) -> [UIScreenEdgePanGestureRecognizer] {

--- a/Pod/Classes/SideMenuManager.swift
+++ b/Pod/Classes/SideMenuManager.swift
@@ -14,7 +14,7 @@
      // Note that these continue to work on the Navigation Controller independent of the View Controller it displays!
      SideMenuManager.menuAddPanGestureToPresent(toView: self.navigationController!.navigationBar)
      SideMenuManager.menuAddScreenEdgePanGesturesToPresent(toView: self.navigationController!.view)
- */
+*/
 
 open class SideMenuManager : NSObject {
     
@@ -257,7 +257,7 @@ open class SideMenuManager : NSObject {
      
      - Parameter toView: The view to add gestures to.
      - Parameter forMenu: The menu (left or right) you want to add a gesture for. If unspecified, gestures will be added for both sides.
-
+ 
      - Returns: The array of screen edge gestures added to `toView`.
      */
     @discardableResult open class func menuAddScreenEdgePanGesturesToPresent(toView: UIView, forMenu:UIRectEdge? = nil) -> [UIScreenEdgePanGestureRecognizer] {

--- a/Pod/Classes/SideMenuManager.swift
+++ b/Pod/Classes/SideMenuManager.swift
@@ -18,6 +18,14 @@
 
 open class SideMenuManager : NSObject {
     
+    @objc public enum MenuPushBehavior : Int {
+        case defaultBehavior
+        case popWhenPossible
+        case replace
+        case preserve
+        case preserveAndHideBackButton
+    }
+    
     @objc public enum MenuPresentMode : Int {
         case menuSlideIn
         case viewSlideOut
@@ -32,6 +40,18 @@ open class SideMenuManager : NSObject {
     }
 
     /**
+     The push behavior of the menu.
+     
+     There are six modes in MenuPushBehavior:
+     - defaultBehavior: The view controller is simply pushed into the stack.
+     - popWhenPossible: Pops to any view controller already in the navigation stack instead of the view controller being pushed if they share the same class.
+     - preserve: Retrieves each already created view controller to front when called.
+     - preserveAndHideBackButton: Retrieves each already created view controller to front when called, and hides the back button.
+     - replace: Releases the current view controller and pushes the new view controller.
+     */
+    open static var menuPushBehavior: MenuPushBehavior = .defaultBehavior
+
+    /**
      The presentation mode of the menu.
      
      There are four modes in MenuPresentMode:
@@ -41,15 +61,9 @@ open class SideMenuManager : NSObject {
      - menuDissolveIn: The menu dissolves in over the existing view controller.
      */
     open static var menuPresentMode: MenuPresentMode = .viewSlideOut
-    
-    /// Retrieves each already created view controller to front when called. Disables navigation back button. Defaults to false.
-    open static var menuPreserveViewOnPush = false
-    
+
     /// Prevents the same view controller (or a view controller of the same class) from being pushed more than once. Defaults to true.
     open static var menuAllowPushOfSameClassTwice = true
-    
-    /// Pops to any view controller already in the navigation stack instead of the view controller being pushed if they share the same class. Defaults to false.
-    open static var menuAllowPopIfPossible = false
     
     /// Width of the menu when presented on screen, showing the existing view controller in the remaining space. Default is 75% of the screen width.
     open static var menuWidth: CGFloat = max(round(min((appScreenRect.width), (appScreenRect.height)) * 0.75), 240)
@@ -96,8 +110,37 @@ open class SideMenuManager : NSObject {
     /// When true, pushViewController called within the menu it will push the new view controller inside of the menu. Otherwise, it is pushed on the menu's presentingViewController. Default is false.
     open static var menuAllowSubmenus: Bool = false
     
-    /// When true, pushViewController will replace the last view controller in the navigation controller's viewController stack instead of appending to it. This makes menus similar to tab bar controller behavior.
-    open static var menuReplaceOnPush: Bool = false
+    /// -Warning: Deprecated. Use `menuPushBehavior = .popWhenPossible` instead.
+    @available(*, deprecated, renamed: "menuPushBehavior", message: "Use `menuPushBehavior = .popWhenPossible` instead.")
+    open static var menuAllowPopIfPossible: Bool {
+        get {
+            if menuPushBehavior == .popWhenPossible {
+                return true
+            }
+            return false
+        }
+        set {
+            if newValue {
+                menuPushBehavior = .popWhenPossible
+            }
+        }
+    }
+    
+    /// -Warning: Deprecated. Use `menuPushBehavior = .replace` instead.
+    @available(*, deprecated, renamed: "menuPushBehavior", message: "Use `menuPushBehavior = .replace` instead.")
+    open static var menuReplaceOnPush: Bool {
+        get {
+            if menuPushBehavior == .replace {
+                return true
+            }
+            return false
+        }
+        set {
+            if newValue {
+                menuPushBehavior = .replace
+            }
+        }
+    }
     
     /// -Warning: Deprecated. Use `menuAnimationTransformScaleFactor` instead.
     @available(*, deprecated, renamed: "menuAnimationTransformScaleFactor")

--- a/Pod/Classes/UISideMenuNavigationController.swift
+++ b/Pod/Classes/UISideMenuNavigationController.swift
@@ -125,7 +125,7 @@ open class UISideMenuNavigationController: UINavigationController {
             super.pushViewController(viewController, animated: animated)
             return
         }
-        
+
         let tabBarController = presentingViewController as? UITabBarController
         guard let navigationController = (tabBarController?.selectedViewController ?? presentingViewController) as? UINavigationController else {
             print("SideMenu Warning: attempt to push a View Controller from \(presentingViewController.self) where its navigationController == nil. It must be embedded in a Navigation Controller for this to work.")

--- a/Pod/Classes/UISideMenuNavigationController.swift
+++ b/Pod/Classes/UISideMenuNavigationController.swift
@@ -97,22 +97,22 @@ open class UISideMenuNavigationController: UINavigationController {
         SideMenuTransition.statusBarView?.isHidden = true
         coordinator.animate(alongsideTransition: { (context) -> Void in
             SideMenuTransition.presentMenuStart(forSize: size)
-        }) { (context) -> Void in
-            SideMenuTransition.statusBarView?.isHidden = false
-        }
+            }) { (context) -> Void in
+                SideMenuTransition.statusBarView?.isHidden = false
+            }
     }
     
     override open func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         if let menuViewController: UINavigationController = SideMenuTransition.presentDirection == .left ? SideMenuManager.menuLeftNavigationController : SideMenuManager.menuRightNavigationController,
             let presentingViewController = menuViewController.presentingViewController as? UINavigationController {
-            presentingViewController.prepare(for: segue, sender: sender)
+                presentingViewController.prepare(for: segue, sender: sender)
         }
     }
     
     override open func shouldPerformSegue(withIdentifier identifier: String, sender: Any?) -> Bool {
         if let menuViewController: UINavigationController = SideMenuTransition.presentDirection == .left ? SideMenuManager.menuLeftNavigationController : SideMenuManager.menuRightNavigationController,
             let presentingViewController = menuViewController.presentingViewController as? UINavigationController {
-            return presentingViewController.shouldPerformSegue(withIdentifier: identifier, sender: sender)
+                return presentingViewController.shouldPerformSegue(withIdentifier: identifier, sender: sender)
         }
         
         return super.shouldPerformSegue(withIdentifier: identifier, sender: sender)

--- a/Pod/Classes/UISideMenuNavigationController.swift
+++ b/Pod/Classes/UISideMenuNavigationController.swift
@@ -161,18 +161,19 @@ open class UISideMenuNavigationController: UINavigationController {
         
         if SideMenuManager.menuPreserveViewOnPush {
             var viewControllers = navigationController.viewControllers
-            let filtered = viewControllers.filter{$0.restorationIdentifier == viewController.restorationIdentifier}
-            if let preservedView = filtered.first {
-                viewControllers = viewControllers.filter() { $0 !== preservedView }
-                viewControllers.append(preservedView)
-                if SideMenuManager.menuTabMode {
-                    navigationController.setViewControllers(viewControllers, animated: false)
+            for (index, subViewController) in navigationController.viewControllers.enumerated() {
+                if type(of: subViewController) == type(of: viewController) {
+                    viewControllers.remove(at: index)
+                    viewControllers.append(subViewController)
+                    if SideMenuManager.menuTabMode {
+                        navigationController.setViewControllers(viewControllers, animated: false)
+                        CATransaction.commit()
+                        return
+                    }
+                    navigationController.setViewControllers(viewControllers, animated: animated)
                     CATransaction.commit()
                     return
                 }
-                navigationController.setViewControllers(viewControllers, animated: animated)
-                CATransaction.commit()
-                return
             }
             if SideMenuManager.menuTabMode {
                 navigationController.pushViewController(viewController, animated: false)

--- a/Pod/Classes/UISideMenuNavigationController.swift
+++ b/Pod/Classes/UISideMenuNavigationController.swift
@@ -147,11 +147,6 @@ open class UISideMenuNavigationController: UINavigationController {
         if SideMenuManager.menuAllowPopIfPossible {
             for subViewController in navigationController.viewControllers {
                 if type(of: subViewController) == type(of: viewController) {
-                    if SideMenuManager.menuTabMode {
-                        navigationController.popToViewController(subViewController, animated: false)
-                        CATransaction.commit()
-                        return
-                    }
                     navigationController.popToViewController(subViewController, animated: animated)
                     CATransaction.commit()
                     return
@@ -161,22 +156,11 @@ open class UISideMenuNavigationController: UINavigationController {
         
         if SideMenuManager.menuPreserveViewOnPush {
             var viewControllers = navigationController.viewControllers
-            for (index, subViewController) in navigationController.viewControllers.enumerated() {
-                if type(of: subViewController) == type(of: viewController) {
-                    viewControllers.remove(at: index)
-                    viewControllers.append(subViewController)
-                    if SideMenuManager.menuTabMode {
-                        navigationController.setViewControllers(viewControllers, animated: false)
-                        CATransaction.commit()
-                        return
-                    }
-                    navigationController.setViewControllers(viewControllers, animated: animated)
-                    CATransaction.commit()
-                    return
-                }
-            }
-            if SideMenuManager.menuTabMode {
-                navigationController.pushViewController(viewController, animated: false)
+            let filtered = viewControllers.filter {preservedViewController in type(of: preservedViewController) == type(of: viewController)}
+            if let preservedViewController = filtered.first {
+                viewControllers = viewControllers.filter() { subController !== preservedViewController }
+                viewControllers.append(preservedViewController)
+                navigationController.setViewControllers(viewControllers, animated: animated)
                 CATransaction.commit()
                 return
             }
@@ -189,23 +173,12 @@ open class UISideMenuNavigationController: UINavigationController {
             var viewControllers = navigationController.viewControllers
             viewControllers.removeLast()
             viewControllers.append(viewController)
-            if SideMenuManager.menuTabMode {
-                navigationController.setViewControllers(viewControllers, animated: false)
-                CATransaction.commit()
-                return
-            }
             navigationController.setViewControllers(viewControllers, animated: animated)
             CATransaction.commit()
             return
         }
         
         if let lastViewController = navigationController.viewControllers.last, !SideMenuManager.menuAllowPushOfSameClassTwice && type(of: lastViewController) == type(of: viewController) {
-            CATransaction.commit()
-            return
-        }
-        
-        if SideMenuManager.menuTabMode {
-            navigationController.pushViewController(viewController, animated: false)
             CATransaction.commit()
             return
         }

--- a/Pod/Classes/UISideMenuNavigationController.swift
+++ b/Pod/Classes/UISideMenuNavigationController.swift
@@ -140,9 +140,12 @@ open class UISideMenuNavigationController: UINavigationController {
             self.visibleViewController?.viewWillAppear(false) // Hack: force selection to get cleared on UITableViewControllers when reappearing using custom transitions
         })
         
+        let areAnimationsEnabled = UIView.areAnimationsEnabled
+        UIView.setAnimationsEnabled(true)
         UIView.animate(withDuration: SideMenuManager.menuAnimationDismissDuration, animations: { () -> Void in
             SideMenuTransition.hideMenuStart()
         })
+        UIView.setAnimationsEnabled(areAnimationsEnabled)
         
         if SideMenuManager.menuAllowPopIfPossible {
             for subViewController in navigationController.viewControllers {
@@ -156,9 +159,10 @@ open class UISideMenuNavigationController: UINavigationController {
         
         if SideMenuManager.menuPreserveViewOnPush {
             var viewControllers = navigationController.viewControllers
-            let filtered = viewControllers.filter {preservedViewController in type(of: preservedViewController) == type(of: viewController)}
+            let filtered = viewControllers.filter { preservedViewController in type(of: preservedViewController) == type(of: viewController) }
             if let preservedViewController = filtered.first {
-                viewControllers = viewControllers.filter() { subController !== preservedViewController }
+                viewControllers = viewControllers.filter { subViewController in subViewController !== preservedViewController }
+                preservedViewController.navigationItem.hidesBackButton = true
                 viewControllers.append(preservedViewController)
                 navigationController.setViewControllers(viewControllers, animated: animated)
                 CATransaction.commit()

--- a/Pod/Classes/UISideMenuNavigationController.swift
+++ b/Pod/Classes/UISideMenuNavigationController.swift
@@ -99,7 +99,7 @@ open class UISideMenuNavigationController: UINavigationController {
             SideMenuTransition.presentMenuStart(forSize: size)
             }) { (context) -> Void in
                 SideMenuTransition.statusBarView?.isHidden = false
-            }
+        }
     }
     
     override open func prepare(for segue: UIStoryboardSegue, sender: Any?) {

--- a/Pod/Classes/UISideMenuNavigationController.swift
+++ b/Pod/Classes/UISideMenuNavigationController.swift
@@ -168,6 +168,7 @@ open class UISideMenuNavigationController: UINavigationController {
                 CATransaction.commit()
                 return
             }
+            viewController.navigationItem.hidesBackButton = true
             navigationController.pushViewController(viewController, animated: animated)
             CATransaction.commit()
             return

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ There are six modes in MenuPushBehavior:
 - popWhenPossible: Pops to any view controller already in the navigation stack instead of the view controller being pushed if they share the same class.
 - preserve: Retrieves each already created view controller to front when called.
 - preserveAndHideBackButton: Retrieves each already created view controller to front when called, and hides the back button.
-- replace: Releases the current view controller and pushes the new view controller.
+- replace: Releases the current view controller and pushes the new view controller. Hides the back button by default.
 */
 open static var menuPushBehavior: MenuPushBehavior = .defaultBehavior
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,12 @@ There are four modes in MenuPresentMode:
 */
 open static var menuPresentMode: MenuPresentMode = .viewSlideOut
 
+/// Retrieves each already created view controller to front when called. Requires class restoration identifiers. Defaults to false.
+open static var menuPreserveViewOnPush = false
+
+/// Mimics a tab function, by instantly presenting the view controller. Defaults to false.
+open static var menuTabMode = false
+
 /// Prevents the same view controller (or a view controller of the same class) from being pushed more than once. Defaults to true.
 open static var menuAllowPushOfSameClassTwice = true
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,18 @@ That's it.
 Just type `SideMenuManager.menu...` and code completion will show you everything you can customize (defaults are shown below for reference):
 ``` swift
 /**
+The push behavior of the menu.
+
+There are six modes in MenuPushBehavior:
+- defaultBehavior: The view controller is simply pushed into the stack.
+- popWhenPossible: Pops to any view controller already in the navigation stack instead of the view controller being pushed if they share the same class.
+- preserve: Retrieves each already created view controller to front when called.
+- preserveAndHideBackButton: Retrieves each already created view controller to front when called, and hides the back button.
+- replace: Releases the current view controller and pushes the new view controller.
+*/
+open static var menuPushBehavior: MenuPushBehavior = .defaultBehavior
+
+/**
 The presentation mode of the menu.
 
 There are four modes in MenuPresentMode:
@@ -130,14 +142,8 @@ There are four modes in MenuPresentMode:
 */
 open static var menuPresentMode: MenuPresentMode = .viewSlideOut
 
-/// Retrieves each already created view controller to front when called. Disables navigation back button. Defaults to false.
-open static var menuPreserveViewOnPush = false
-
 /// Prevents the same view controller (or a view controller of the same class) from being pushed more than once. Defaults to true.
 open static var menuAllowPushOfSameClassTwice = true
-
-/// Pops to any view controller already in the navigation stack instead of the view controller being pushed if they share the same class. Defaults to false.
-open static var menuAllowPopIfPossible = false
 
 /// Width of the menu when presented on screen, showing the existing view controller in the remaining space. Default is 75% of the screen width.
 open static var menuWidth: CGFloat = max(round(min((appScreenRect.width), (appScreenRect.height)) * 0.75), 240)
@@ -186,9 +192,6 @@ open static var menuFadeStatusBar = true
 
 /// When true, pushViewController called within the menu it will push the new view controller inside of the menu. Otherwise, it is pushed on the menu's presentingViewController. Default is false.
 open static var menuAllowSubmenus: Bool = false
-
-/// When true, pushViewController will replace the last view controller in the navigation controller's viewController stack instead of appending to it. This makes menus similar to tab bar controller behavior.
-open static var menuReplaceOnPush: Bool = false
 
 /**
  The blur effect style of the menu if the menu's root view controller is a UITableViewController or UICollectionViewController.

--- a/README.md
+++ b/README.md
@@ -133,9 +133,6 @@ open static var menuPresentMode: MenuPresentMode = .viewSlideOut
 /// Retrieves each already created view controller to front when called. Requires class restoration identifiers. Defaults to false.
 open static var menuPreserveViewOnPush = false
 
-/// Mimics a tab function, by instantly presenting the view controller. Defaults to false.
-open static var menuTabMode = false
-
 /// Prevents the same view controller (or a view controller of the same class) from being pushed more than once. Defaults to true.
 open static var menuAllowPushOfSameClassTwice = true
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ There are four modes in MenuPresentMode:
 */
 open static var menuPresentMode: MenuPresentMode = .viewSlideOut
 
-/// Retrieves each already created view controller to front when called. Requires class restoration identifiers. Defaults to false.
+/// Retrieves each already created view controller to front when called. Disables navigation back button. Defaults to false.
 open static var menuPreserveViewOnPush = false
 
 /// Prevents the same view controller (or a view controller of the same class) from being pushed more than once. Defaults to true.


### PR DESCRIPTION
- Added MenuPushBehavior enum.
        There are six modes in MenuPushBehavior:
     - defaultBehavior: The view controller is simply pushed into the stack.
     - popWhenPossible: Pops to any view controller already in the navigation stack instead of the view controller being pushed if they share the same class.
     - preserve: Retrieves each already created view controller to front when called.
     - preserveAndHideBackButton: Retrieves each already created view controller to front when called, and hides the back button.
     - replace: Releases the current view controller and pushes the new view controller.
     
- New default function of SideMenu is to hide the SideMenu before every transition.

Simple changes, functionality of SideMenu as a whole remains unchanged.

_Feature request (already coded) to create more of a 'tab' experience_
#131 