### PR TITLE
Fix deprecations and warnings in swift 3.1

### DIFF
--- a/Pod/Classes/SideMenuTransition.swift
+++ b/Pod/Classes/SideMenuTransition.swift
@@ -148,7 +148,7 @@ open class SideMenuTransition: UIPercentDrivenInteractiveTransition {
             view.transform = transform
             if velocity >= 100 || velocity >= -50 && abs(distance) >= 0.5 {
                 // bug workaround: animation briefly resets after call to finishInteractiveTransition() but before animateTransition completion is called.
-                if ProcessInfo().operatingSystemVersion.majorVersion == 8 && singleton.percentComplete > 1 - CGFloat(FLT_EPSILON) {
+                if ProcessInfo().operatingSystemVersion.majorVersion == 8 && singleton.percentComplete > 1 - CGFloat.ulpOfOne {
                     singleton.update(0.9999)
                 }
                 singleton.finish()
@@ -185,7 +185,7 @@ open class SideMenuTransition: UIPercentDrivenInteractiveTransition {
             let velocity = pan.velocity(in: pan.view!).x * direction
             if velocity >= 100 || velocity >= -50 && distance >= 0.5 {
                 // bug workaround: animation briefly resets after call to finishInteractiveTransition() but before animateTransition completion is called.
-                if ProcessInfo().operatingSystemVersion.majorVersion == 8 && singleton.percentComplete > 1 - CGFloat(FLT_EPSILON) {
+                if ProcessInfo().operatingSystemVersion.majorVersion == 8 && singleton.percentComplete > 1 - CGFloat.ulpOfOne {
                     singleton.update(0.9999)
                 }
                 singleton.finish()

--- a/Pod/Classes/UISideMenuNavigationController.swift
+++ b/Pod/Classes/UISideMenuNavigationController.swift
@@ -132,7 +132,7 @@ open class UISideMenuNavigationController: UINavigationController {
 
         let tabBarController = presentingViewController as? UITabBarController
         guard let navigationController = (tabBarController?.selectedViewController ?? presentingViewController) as? UINavigationController else {
-            print("SideMenu Warning: attempt to push a View Controller from \(presentingViewController.self) where its navigationController == nil. It must be embedded in a Navigation Controller for this to work.")
+            print("SideMenu Warning: attempt to push a View Controller from \(String(describing: presentingViewController.self)) where its navigationController == nil. It must be embedded in a Navigation Controller for this to work.")
             return
         }
         


### PR DESCRIPTION
This fixes the 3 warnings when compiling with XCode 8.3 beta and Swift 3.1