### PR TITLE
Animate shadowOpacity on menu

### DIFF
--- a/Pod/Classes/SideMenuManager.swift
+++ b/Pod/Classes/SideMenuManager.swift
@@ -105,6 +105,9 @@ open class SideMenuManager : NSObject {
     
     /// Draws the `menuAnimationBackgroundColor` behind the status bar. Default is true.
     open static var menuFadeStatusBar = true
+
+	/// Color of status bar during presentation. Default is menuAnimationBackgroundColor.
+	open static var menuStatusBarColor: UIColor?
     
     /// The animation options when a menu is displayed. Ignored when displayed with a gesture.
     open static var menuAnimationOptions: UIViewAnimationOptions = .curveEaseInOut

--- a/Pod/Classes/SideMenuTransition.swift
+++ b/Pod/Classes/SideMenuTransition.swift
@@ -206,6 +206,8 @@ open class SideMenuTransition: UIPercentDrivenInteractiveTransition {
             } else {
                 singleton.cancel()
                 activeGesture = nil
+				// bug workaround: for some reason the shadowOpacity does not animate from previous value when cancelled
+				viewControllerForMenu?.view.layer.shadowOpacity = SideMenuManager.menuShadowOpacity
             }
         }
     }
@@ -347,9 +349,6 @@ open class SideMenuTransition: UIPercentDrivenInteractiveTransition {
             return
         }
 
-		mainViewController.view.layer.shadowOpacity = SideMenuManager.menuShadowOpacity
-		menuView.layer.shadowOpacity = SideMenuManager.menuShadowOpacity
-
         switch SideMenuManager.menuPresentMode {
         case .menuSlideIn, .menuDissolveIn, .viewSlideInOut:
             if SideMenuManager.menuParallaxStrength != 0 {
@@ -404,13 +403,12 @@ open class SideMenuTransition: UIPercentDrivenInteractiveTransition {
     }
 
 	fileprivate static func addShadowAnimationTo(layer: CALayer, presenting: Bool) {
-
 		let toValue = presenting ? SideMenuManager.menuShadowOpacity : 0.0
 		let fromValue = presenting ? 0.0 : SideMenuManager.menuShadowOpacity
 
 		let animation = CABasicAnimation(keyPath: "shadowOpacity")
+		animation.fillMode = kCAFillModeForwards
 		animation.fromValue = fromValue
-		animation.toValue = toValue
 		animation.timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseInEaseOut)
 
 		layer.add(animation, forKey: nil)

--- a/Pod/Classes/SideMenuTransition.swift
+++ b/Pod/Classes/SideMenuTransition.swift
@@ -38,12 +38,8 @@ open class SideMenuTransition: UIPercentDrivenInteractiveTransition {
             guard let statusBarView = statusBarView else {
                 return
             }
-            
-            if let menuShrinkBackgroundColor = SideMenuManager.menuAnimationBackgroundColor {
-                statusBarView.backgroundColor = menuShrinkBackgroundColor
-            } else {
-                statusBarView.backgroundColor = UIColor.black
-            }
+
+            statusBarView.backgroundColor = SideMenuManager.menuStatusBarColor ?? SideMenuManager.menuAnimationBackgroundColor ?? .black
             statusBarView.isUserInteractionEnabled = false
         }
     }
@@ -312,7 +308,7 @@ open class SideMenuTransition: UIPercentDrivenInteractiveTransition {
         SideMenuTransition.tapView?.bounds = mainViewController.view.bounds
         SideMenuTransition.statusBarView?.frame = statusBarFrame
         SideMenuTransition.statusBarView?.alpha = 1
-        
+
         switch SideMenuManager.menuPresentMode {
             
         case .viewSlideOut, .viewSlideInOut:
@@ -320,6 +316,7 @@ open class SideMenuTransition: UIPercentDrivenInteractiveTransition {
             mainViewController.view.layer.shadowRadius = SideMenuManager.menuShadowRadius
 			mainViewController.view.layer.shadowOpacity = SideMenuManager.menuShadowOpacity
             mainViewController.view.layer.shadowOffset = CGSize(width: 0, height: 0)
+			mainViewController.view.layer.shadowPath = UIBezierPath(rect: mainViewController.view.bounds).cgPath
             let direction:CGFloat = SideMenuTransition.presentDirection == .left ? 1 : -1
             mainViewController.view.frame.origin.x = direction * (menuView.frame.width)
             
@@ -328,6 +325,7 @@ open class SideMenuTransition: UIPercentDrivenInteractiveTransition {
                 menuView.layer.shadowColor = SideMenuManager.menuShadowColor.cgColor
                 menuView.layer.shadowRadius = SideMenuManager.menuShadowRadius
                 menuView.layer.shadowOffset = CGSize(width: 0, height: 0)
+				menuView.layer.shadowPath = UIBezierPath(rect: menuView.bounds).cgPath
 				SideMenuTransition.addShadowAnimationTo(layer: menuView.layer, presenting: true)
 				SideMenuTransition.addShadowAnimationTo(layer: mainViewController.view.layer, presenting: true)
             }
@@ -345,7 +343,7 @@ open class SideMenuTransition: UIPercentDrivenInteractiveTransition {
     
     internal class func presentMenuComplete() {
         guard let mainViewController = presentingViewControllerForMenu,
-			let menuView = viewControllerForMenu?.view else {
+			let _ = viewControllerForMenu?.view else {
             return
         }
 


### PR DESCRIPTION
`shadowOpacity` is not a view based animatable property like `alpha`. The shadowOpacity needs to be wrapped in a CAAnimation to animate alongside the menu transition. This removes the bug of the shadow appearing/disappearing instantly when opening and closing the menu. Also added a `menuStatusBarColor` property on `SideMenuManager`. Let me know if you have any questions. 