### PR TITLE
Add missing designated initialiser to UITableViewVibrantCell

### DIFF
--- a/Pod/Classes/UITableViewVibrantCell.swift
+++ b/Pod/Classes/UITableViewVibrantCell.swift
@@ -14,6 +14,10 @@ open class UITableViewVibrantCell: UITableViewCell {
     fileprivate var vibrancySelectedBackgroundView:UIVisualEffectView = UIVisualEffectView()
     fileprivate var defaultSelectedBackgroundView:UIView?
     
+    public override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+    }
+    
     required public init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         


### PR DESCRIPTION
So cell can be registered with UITableView without subclassing for simple use cases. Without this initialiser dequeuing instance of the cell will cause a crash.

```
// Register with tableView
self.tableView.register(UITableViewVibrantCell.self, forCellReuseIdentifier: identifier)
// ...
// Crash when attempting to dequeue cell without this PR
let cell = tableView.dequeueReusableCell(withIdentifier: identifier, for: indexPath)
```