### PR TITLE
Animate side menu dismiss when pushing views non animated 

### DIFF
--- a/Pod/Classes/SideMenuManager.swift
+++ b/Pod/Classes/SideMenuManager.swift
@@ -127,6 +127,9 @@ open class SideMenuManager : NSObject {
      */
     open var menuDismissOnPush = true
     
+    /// Uses the menu dismiss animation even if pushing a view is not animated itself.
+    open var menuAnimateDismissOnNonAnimatedPush = false
+    
     /// Default instance of SideMenuManager.
     open static let `default` = SideMenuManager()
     internal var transition: SideMenuTransition!

--- a/Pod/Classes/UISideMenuNavigationController.swift
+++ b/Pod/Classes/UISideMenuNavigationController.swift
@@ -258,7 +258,7 @@ open class UISideMenuNavigationController: UINavigationController {
                 self.dismiss(animated: animated, completion: nil)
             })
         
-            if animated {
+            if animated || sideMenuManager.menuAnimateDismissOnNonAnimatedPush {
                 let areAnimationsEnabled = UIView.areAnimationsEnabled
                 UIView.setAnimationsEnabled(true)
                 UIView.animate(withDuration: sideMenuManager.menuAnimationDismissDuration,

--- a/README.md
+++ b/README.md
@@ -224,6 +224,9 @@ of the view controller being presented in storyboard or during its initalization
 */
 open var menuDismissOnPush = true
 
+/// Uses the menu dismiss animation even if pushing a view is not animated itself.
+open var menuAnimateDismissOnNonAnimatedPush = false
+
 /**
 The blur effect style of the menu if the menu's root view controller is a UITableViewController or UICollectionViewController.
 


### PR DESCRIPTION
It should be possible to have the menu slide out even if pushing the new view is not animated itself (animating both can look a bit weird when relying on 'animated' only)