### PR TITLE
fix objc inference in swift 4

### DIFF
--- a/Pod/Classes/SideMenuManager.swift
+++ b/Pod/Classes/SideMenuManager.swift
@@ -16,6 +16,7 @@
      SideMenuManager.menuAddScreenEdgePanGesturesToPresent(toView: self.navigationController!.view)
 */
 
+@objcMembers
 open class SideMenuManager : NSObject {
     
     @objc public enum MenuPushStyle : Int {


### PR DESCRIPTION
In swift 4, swift subclasses of objective-c classes don't export members by default, see https://help.apple.com/xcode/mac/current/#/deve838b19a1 and http://evgenii.com/blog/disabling-swift3-objc-inference-in-xcode9/

Alternatively, `@objc` could be added to all members which should be exported.

I'm not sure if other classes like SideMenuTransition should also be adapted, but I didn't need it.