### PR TITLE
Fix for unreliable dismissal by tap gesture

### DIFF
--- a/Pod/Classes/UISideMenuNavigationController.swift
+++ b/Pod/Classes/UISideMenuNavigationController.swift
@@ -669,7 +669,7 @@ private extension UISideMenuNavigationController {
     }
 
     @objc func handleDismissMenuTap(_ tap: UITapGestureRecognizer) {
-        guard view.window?.hitTest(tap.location(in: nil), with: nil) == view.superview else { return }
+        guard !view.bounds.contains(tap.location(in: view)) else { return }
         dismissMenu()
     }
 


### PR DESCRIPTION
There is an issue in the current build with dismissing using a tap gesture.
This can be reproduced in the example app by opening left side menu while in landscape orientation and tapping on the far right.