### PR TITLE
Propagate configured onTopShadowOffset to layer

### DIFF
--- a/Pod/Classes/SideMenuPresentationController.swift
+++ b/Pod/Classes/SideMenuPresentationController.swift
@@ -221,7 +221,7 @@ private extension SideMenuPresentationController {
         view.layer.shadowColor = config.presentationStyle.onTopShadowColor.cgColor
         view.layer.shadowRadius = config.presentationStyle.onTopShadowRadius
         view.layer.shadowOpacity = config.presentationStyle.onTopShadowOpacity
-        view.layer.shadowOffset = CGSize(width: 0, height: 0)
+        view.layer.shadowOffset = config.presentationStyle.onTopShadowOffset
     }
 
     func addParallax(to view: UIView) {


### PR DESCRIPTION
It seems like you missed this. This property isn't actually ever read anywhere and had no effect.