### PR TITLE
SideMenu delegate was made public

### DIFF
--- a/Pod/Classes/SideMenuNavigationController.swift
+++ b/Pod/Classes/SideMenuNavigationController.swift
@@ -80,7 +80,7 @@ open class SideMenuNavigationController: UINavigationController {
     private var transitionController: SideMenuTransitionController?
 
     /// Delegate for receiving appear and disappear related events. If `nil` the visible view controller that displays a `SideMenuNavigationController` automatically receives these events.
-    internal weak var sideMenuDelegate: SideMenuNavigationControllerDelegate?
+    public weak var sideMenuDelegate: SideMenuNavigationControllerDelegate?
 
     /// The swipe to dismiss gesture.
     open private(set) weak var swipeToDismissGesture: UIPanGestureRecognizer? = nil


### PR DESCRIPTION
`sideMenuDelegate` is internal at the moment. I used SideMenu with UITabBarController, so I needed to set `sideMenuDelegate` manually and didn't have an opportunity.