### PR TITLE
SwiftPM support & Xcode 11 compile fix

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version:4.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "SideMenu",
+    products: [
+        .library(name: "SideMenu",  targets: ["SideMenu"])
+    ],
+    dependencies: [],
+    targets: [
+        .target(name: "SideMenu", path: "Pod/Classes")
+    ]
+)
+

--- a/Pod/Classes/Extensions.swift
+++ b/Pod/Classes/Extensions.swift
@@ -20,7 +20,7 @@ internal extension UIView {
     }
 
     func bringToFront() {
-        self.superview?.bringSubviewToFront(self)
+        self.superview?.bringSubview(toFront: self)
     }
 
     func untransform(_ block: () -> Void) {

--- a/Pod/Classes/SideMenuInteractionController.swift
+++ b/Pod/Classes/SideMenuInteractionController.swift
@@ -23,7 +23,7 @@ internal final class SideMenuInteractionController: UIPercentDrivenInteractiveTr
         self.completionCurve = completionCurve
 
         guard cancelWhenBackgrounded else { return }
-        NotificationCenter.default.addObserver(self, selector: #selector(handleNotification), name: UIApplication.didEnterBackgroundNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(handleNotification), name: .UIApplicationDidEnterBackground, object: nil)
     }
 
     override func cancel() {
@@ -57,7 +57,7 @@ private extension SideMenuInteractionController {
 
     @objc func handleNotification(notification: NSNotification) {
         switch notification.name {
-        case UIApplication.didEnterBackgroundNotification:
+        case .UIApplicationDidEnterBackground:
             cancel()
         default: break
         }

--- a/Pod/Classes/SideMenuNavigationController.swift
+++ b/Pod/Classes/SideMenuNavigationController.swift
@@ -606,8 +606,8 @@ private extension SideMenuNavigationController {
     func registerForNotifications() {
         NotificationCenter.default.removeObserver(self)
 
-        [UIApplication.willChangeStatusBarFrameNotification,
-        UIApplication.didEnterBackgroundNotification].forEach {
+        [.UIApplicationWillChangeStatusBarFrame,
+         .UIApplicationDidEnterBackground].forEach {
             NotificationCenter.default.addObserver(self, selector: #selector(handleNotification), name: $0, object: nil)
         }
     }
@@ -616,12 +616,12 @@ private extension SideMenuNavigationController {
         guard isHidden else { return }
 
         switch notification.name {
-        case UIApplication.willChangeStatusBarFrameNotification:
+        case .UIApplicationWillChangeStatusBarFrame:
             // Dismiss for in-call status bar changes but not rotation
             if !rotating {
                 dismissMenu()
             }
-        case UIApplication.didEnterBackgroundNotification:
+        case .UIApplicationDidEnterBackground:
             if dismissWhenBackgrounded {
                 dismissMenu()
             }


### PR DESCRIPTION
Added the Swift Package Manager manifest and fixed the notification names to compile on Xcode 11 with the latest version of Swift 5. Tested with the latest Xcode 11 beta