### PR TITLE
Fixed circular reference in Xcode 11.4b1

### DIFF
--- a/Pod/Classes/SideMenuNavigationController.swift
+++ b/Pod/Classes/SideMenuNavigationController.swift
@@ -73,7 +73,7 @@ internal protocol SideMenuNavigationControllerTransitionDelegate: class {
     func sideMenuTransitionDidDismiss(menu: Menu)
 }
 
-public struct SideMenuSettings: SideMenuNavigationController.Model, InitializableStruct {
+public struct SideMenuSettings: Model, InitializableStruct {
     public var allowPushOfSameClassTwice: Bool = true
     public var alwaysAnimate: Bool = true
     public var animationOptions: UIView.AnimationOptions = .curveEaseInOut
@@ -105,11 +105,10 @@ public struct SideMenuSettings: SideMenuNavigationController.Model, Initializabl
 }
 
 internal typealias Menu = SideMenuNavigationController
+internal typealias Model = MenuModel & PresentationModel & AnimationModel
 
 @objcMembers
 open class SideMenuNavigationController: UINavigationController {
-
-    internal typealias Model = MenuModel & PresentationModel & AnimationModel
 
     private lazy var _leftSide = Protected(false) { [weak self] oldValue, newValue in
         guard self?.isHidden != false else {
@@ -336,7 +335,7 @@ open class SideMenuNavigationController: UINavigationController {
 }
 
 // Interface
-extension SideMenuNavigationController: SideMenuNavigationController.Model {
+extension SideMenuNavigationController: Model {
 
     @IBInspectable open var allowPushOfSameClassTwice: Bool {
         get { return settings.allowPushOfSameClassTwice }


### PR DESCRIPTION
Fixed a circular reference error being thrown in Beta 1 of Xcode 11.4, I'm pretty sure it's related to Swift 5.2 and that the error is here to stay, but you might want to hold off this PR until the stable version comes out.