### PR TITLE
Replace 'class' with 'AnyObject'

### DIFF
--- a/Pod/Classes/Initializable.swift
+++ b/Pod/Classes/Initializable.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-internal protocol InitializableClass: class {
+internal protocol InitializableClass: AnyObject {
     init()
 }
 

--- a/Pod/Classes/SideMenuAnimationController.swift
+++ b/Pod/Classes/SideMenuAnimationController.swift
@@ -22,7 +22,7 @@ internal protocol AnimationModel {
     var usingSpringWithDamping: CGFloat { get }
 }
 
-internal protocol SideMenuAnimationControllerDelegate: class {
+internal protocol SideMenuAnimationControllerDelegate: AnyObject {
     func sideMenuAnimationController(_ animationController: SideMenuAnimationController, didDismiss viewController: UIViewController)
     func sideMenuAnimationController(_ animationController: SideMenuAnimationController, didPresent viewController: UIViewController)
 }

--- a/Pod/Classes/SideMenuNavigationController.swift
+++ b/Pod/Classes/SideMenuNavigationController.swift
@@ -69,7 +69,7 @@ internal protocol MenuModel {
     @objc optional func sideMenuDidDisappear(menu: SideMenuNavigationController, animated: Bool)
 }
 
-internal protocol SideMenuNavigationControllerTransitionDelegate: class {
+internal protocol SideMenuNavigationControllerTransitionDelegate: AnyObject {
     func sideMenuTransitionDidDismiss(menu: Menu)
 }
 

--- a/Pod/Classes/SideMenuPresentationController.swift
+++ b/Pod/Classes/SideMenuPresentationController.swift
@@ -20,7 +20,7 @@ internal protocol PresentationModel {
     var menuWidth: CGFloat { get }
 }
 
-internal protocol SideMenuPresentationControllerDelegate: class {
+internal protocol SideMenuPresentationControllerDelegate: AnyObject {
     func sideMenuPresentationControllerDidTap(_ presentationController: SideMenuPresentationController)
     func sideMenuPresentationController(_ presentationController: SideMenuPresentationController, didPanWith gesture: UIPanGestureRecognizer)
 }

--- a/Pod/Classes/SideMenuTransitionController.swift
+++ b/Pod/Classes/SideMenuTransitionController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-internal protocol SideMenuTransitionControllerDelegate: class {
+internal protocol SideMenuTransitionControllerDelegate: AnyObject {
     func sideMenuTransitionController(_ transitionController: SideMenuTransitionController, didDismiss viewController: UIViewController)
     func sideMenuTransitionController(_ transitionController: SideMenuTransitionController, didPresent viewController: UIViewController)
 }


### PR DESCRIPTION
Using 'class' keyword for protocol inheritance is deprecated; use 'AnyObject' instead