### PR TITLE
Fix presentation issue

### DIFF
--- a/Pod/Classes/SideMenuAnimationController.swift
+++ b/Pod/Classes/SideMenuAnimationController.swift
@@ -123,7 +123,6 @@ private extension SideMenuAnimationController {
             else { return }
 
         originalSuperview = presentingViewController.view.superview
-        containerView?.addSubview(presentingViewController.view)
         containerView?.addSubview(presentedViewController.view)
     }
 

--- a/Pod/Classes/SideMenuPresentationController.swift
+++ b/Pod/Classes/SideMenuPresentationController.swift
@@ -49,7 +49,7 @@ internal final class SideMenuPresentationController {
         guard config.statusBarEndAlpha > .leastNonzeroMagnitude else { return nil }
 
         return UIView {
-            $0.backgroundColor = config.presentationStyle.backgroundColor
+            $0.backgroundColor = .clear
             $0.autoresizingMask = [.flexibleHeight, .flexibleWidth]
             $0.isUserInteractionEnabled = false
         }
@@ -104,7 +104,6 @@ internal final class SideMenuPresentationController {
         }
 
         presentingViewController.view.isUserInteractionEnabled = config.presentingViewControllerUserInteractionEnabled
-        containerView.backgroundColor = config.presentationStyle.backgroundColor
         
         layerViews()
 

--- a/Pod/Classes/SideMenuPresentationStyle.swift
+++ b/Pod/Classes/SideMenuPresentationStyle.swift
@@ -9,8 +9,6 @@ import UIKit
 
 @objcMembers
 open class SideMenuPresentationStyle: InitializableClass {
-    /// Background color behind the views and status bar color
-    open var backgroundColor: UIColor = .black
     /// The starting alpha value of the menu before it appears
     open var menuStartAlpha: CGFloat = 1
     /// Whether or not the menu is on top. If false, the presenting view is on top. Shadows are applied to the view on top.


### PR DESCRIPTION
Adding the view of the presenting view controller to the transition container view causes an accessibility issue when using the keyboard option. Typical iOS behavior is that a view controller that was presented on top of another view controller will take all the keyboard gestures and that the view under will not be accessible with the keyboard.

The issue here is that by adding the presenting view to the container iOS now will make it on the same level as the presented view with respect to accessibility.

In order to support the change we remove the presenting view from the container, this poses an issue because the presentation style contains a background which now doesn't make much sense to have as it is rendered above the presenting view, so we also remove the option to set a custom background color.